### PR TITLE
Filter for sharp lines

### DIFF
--- a/src/search/defs.rs
+++ b/src/search/defs.rs
@@ -21,6 +21,7 @@ pub const CHECKMATE: i16 = 24_000;
 pub const CHECKMATE_THRESHOLD: i16 = 23_900;
 pub const STALEMATE: i16 = 0;
 pub const DRAW: i16 = 0;
+pub const SHARP_MARGIN: i16 = 30; // centipawn window for good replies
 pub const CHECK_TERMINATION: usize = 0x7FF; // 2.047 nodes
 pub const SEND_STATS: usize = 0x7FFFF; // 524.287 nodes
 pub const MIN_TIME_STATS: u128 = 2_000; // Minimum time for sending stats
@@ -131,6 +132,7 @@ pub struct SearchInfo {
     pub last_curr_move_sent: u128,  // When last current move was sent
     pub allocated_time: u128,       // Allotted msecs to spend on move
     pub terminate: SearchTerminate, // Terminate flag
+    pub root_analysis: Vec<RootMoveAnalysis>,
 }
 
 impl SearchInfo {
@@ -146,6 +148,7 @@ impl SearchInfo {
             last_curr_move_sent: 0,
             allocated_time: 0,
             terminate: SearchTerminate::Nothing,
+            root_analysis: Vec::new(),
         }
     }
 
@@ -231,6 +234,14 @@ impl SearchStats {
             hash_full,
         }
     }
+}
+
+// Holds information about each root move.
+#[derive(PartialEq, Clone)]
+pub struct RootMoveAnalysis {
+    pub mv: Move,
+    pub eval: i16,
+    pub good_replies: usize,
 }
 
 // The search process needs references to a lot of data, such as a copy of


### PR DESCRIPTION
## Summary
- track root move analysis including count of strong replies
- evaluate reply moves at the root and collect stats
- show only sharp root moves (single good reply) in search summaries

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685a764a19ac832b857d0a1659ce23d8